### PR TITLE
Updated the text in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This is a python module to create SPARQL queries for the EU Cellar repository, r
 Import and instantiate the moduel
 
 ```
-from eurlex import Eurlex
+from eurlex.eurlex import Eurlex
 eur = Eurlex()
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ print(x)
 
 To get data associated with an identifier, use `get_data()`. This will return the data as a string,
 ```
-d = eur.get_data("http://publications.europa.eu/resource/celex/32016R0679", type="text")
+d = eur.get_data("http://publications.europa.eu/resource/celex/32016R0679", data_type="text")
 print(d)
 ```
 


### PR DESCRIPTION
In the current README.md file, the import statement and the get_data function was not performing as expected same the statements are copied form the README. Following are the changes made in the README.md file:

1. First Change:
```python
from eurlex import Eurlex
```

As the project structure is the `eurlex` folder comprised of the `eurlex.py` script, and in the script `Eurlex` class is present. Thus the statement will be as follows:

```python
from eurlex.eurlex import Eurlex
```

2. Second Change:
```python
d = eur.get_data("http://publications.europa.eu/resource/celex/32016R0679", type="text")
```
The function `get_data` present in the Eurlex class does not have an argument `type` instead for the same argument of text, title, and ids, the argument name is `data_type`.  Therefore, the following will be the changes

```python
d = eur.get_data("http://publications.europa.eu/resource/celex/32016R0679", data_type="text")
```